### PR TITLE
fix: add <linux/version.h> include

### DIFF
--- a/3_RootkitTechniques/3.7_char_interfering/rootkit.c
+++ b/3_RootkitTechniques/3.7_char_interfering/rootkit.c
@@ -3,6 +3,7 @@
 #include <linux/kernel.h>
 #include <linux/syscalls.h>
 #include <linux/kallsyms.h>
+#include <linux/version.h>
 
 #include "ftrace_helper.h"
 


### PR DESCRIPTION
Looks like you forgot to include `<linux/version.h>` there. This PR fixes it.

Error: 
```sh
$ root@ubuntu2004:/workdir/char-interfering# make all

make -C /lib/modules/5.4.0-66-generic/build M=/workdir/char-interfering modules
make[1]: Entering directory '/usr/src/linux-headers-5.4.0-66-generic'
  CC [M]  /workdir/char-interfering/rootkit.o
In file included from /workdir/char-interfering/rootkit.c:7:
/workdir/char-interfering/ftrace_helper.h:12:32: warning: "LINUX_VERSION_CODE" is not defined, evaluates to 0 [-Wundef]
   12 | #if defined(CONFIG_X86_64) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
      |                                ^~~~~~~~~~~~~~~~~~
/workdir/char-interfering/ftrace_helper.h:12:54: warning: "KERNEL_VERSION" is not defined, evaluates to 0 [-Wundef]
   12 | #if defined(CONFIG_X86_64) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
      |                                                      ^~~~~~~~~~~~~~
/workdir/char-interfering/ftrace_helper.h:12:68: error: missing binary operator before token "("
   12 | #if defined(CONFIG_X86_64) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
      |                                                                    ^
make[2]: *** [scripts/Makefile.build:271: /workdir/char-interfering/rootkit.o] Error 1
make[1]: *** [Makefile:1760: /workdir/char-interfering] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-5.4.0-66-generic'
make: *** [Makefile:4: all] Error 2
```